### PR TITLE
Fix imports for shared widgets

### DIFF
--- a/user_app/lib/features/cart/presentation/pages/checkout_page.dart
+++ b/user_app/lib/features/cart/presentation/pages/checkout_page.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:user_app/features/profile/presentation/pages/shipping_address_list_page.dart';
 import 'package:user_app/features/profile/domain/models/shipping_address.dart';
 import 'package:user_app/features/profile/providers/shipping_address_notifier.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 
 class CheckoutPage extends ConsumerStatefulWidget {
   const CheckoutPage({super.key});

--- a/user_app/lib/features/cart/presentation/pages/shopping_cart_page.dart
+++ b/user_app/lib/features/cart/presentation/pages/shopping_cart_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:user_app/features/cart/providers/cart_notifier.dart';
 import 'package:shared_libs/models/models.dart'; // Use main export
-import 'package:shared_libs/widgets/widgets .dart'; // Use main export
+import 'package:shared_libs/widgets/widgets.dart'; // Use main export
 import 'package:intl/intl.dart'; // For currency formatting
 import 'package:go_router/go_router.dart'; // For navigation
 

--- a/user_app/lib/features/favorites/presentation/pages/favorites_page.dart
+++ b/user_app/lib/features/favorites/presentation/pages/favorites_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_libs/models/models.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:user_app/features/favorites/providers/favorites_notifier.dart';
 import 'package:user_app/features/cart/providers/cart_notifier.dart';
 import 'package:go_router/go_router.dart';

--- a/user_app/lib/features/home/presentation/pages/home_page.dart
+++ b/user_app/lib/features/home/presentation/pages/home_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:user_app/features/products/providers/product_notifier.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:shared_libs/models/models.dart';
 import 'package:go_router/go_router.dart';
 import 'package:user_app/features/cart/providers/cart_notifier.dart';

--- a/user_app/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/user_app/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:shared_libs/services/notification_service.dart';
 import 'package:timeago/timeago.dart' as timeago;
 

--- a/user_app/lib/features/orders/presentation/pages/my_orders_page.dart
+++ b/user_app/lib/features/orders/presentation/pages/my_orders_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:go_router/go_router.dart';
 import 'package:user_app/features/orders/providers/orders_notifier.dart';

--- a/user_app/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/user_app/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 // Needed for CartItemModel
 import 'package:shared_libs/services/services.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:go_router/go_router.dart';
 import '../../../cart/providers/cart_notifier.dart';
 import 'package:user_app/features/auth/providers/auth_notifier.dart';

--- a/user_app/lib/features/orders/presentation/pages/order_details_page.dart
+++ b/user_app/lib/features/orders/presentation/pages/order_details_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_libs/models/models.dart';
 import 'package:shared_libs/services/services.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:user_app/features/cart/providers/cart_notifier.dart';
 import 'package:go_router/go_router.dart';

--- a/user_app/lib/features/profile/presentation/pages/shipping_address_form_page.dart
+++ b/user_app/lib/features/profile/presentation/pages/shipping_address_form_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 
 /// صفحة نموذج عنوان الشحن
 ///

--- a/user_app/lib/features/profile/presentation/pages/shipping_address_list_page.dart
+++ b/user_app/lib/features/profile/presentation/pages/shipping_address_list_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:user_app/features/profile/domain/models/shipping_address.dart';
 import 'package:user_app/features/profile/providers/shipping_address_notifier.dart';
 import 'package:user_app/features/profile/presentation/pages/shipping_address_form_page.dart';

--- a/user_app/lib/features/ratings/presentation/pages/ratings_page.dart
+++ b/user_app/lib/features/ratings/presentation/pages/ratings_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import 'package:user_app/features/ratings/providers/ratings_notifier.dart';
 import 'package:intl/intl.dart';
 

--- a/user_app/lib/features/store/presentation/pages/store_details_page.dart
+++ b/user_app/lib/features/store/presentation/pages/store_details_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_libs/models/models.dart';
 import 'package:shared_libs/services/services.dart';
-import 'package:shared_libs/widgets/widgets .dart';
+import 'package:shared_libs/widgets/widgets.dart';
 import '../../../cart/providers/cart_notifier.dart';
 import '../../../products/providers/product_notifier.dart';
 import 'package:user_app/features/auth/providers/auth_notifier.dart';


### PR DESCRIPTION
## Summary
- fix typo in shared widgets import paths across user_app pages

## Testing
- `melos run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684145ec7e2c8325a3f0054df889aa98