### PR TITLE
Fix shared imports in auth pages

### DIFF
--- a/user_app/lib/features/auth/presentation/pages/forgot_password_page.dart
+++ b/user_app/lib/features/auth/presentation/pages/forgot_password_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';import 'package:shared_libs/utils/validators.dart';import '../../providers/auth_service.dart';
-import '../../../../theme/app_widgets.dart';
-import '../../../../core/constants/route_constants.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_libs/utils/validators.dart';
+import '../../providers/auth_service.dart';
+import 'package:shared_libs/theme/app_widgets.dart';
+import 'package:shared_libs/constants/route_constants.dart';
 
 class ForgotPasswordPage extends ConsumerStatefulWidget {
   const ForgotPasswordPage({Key? key}) : super(key: key);

--- a/user_app/lib/features/auth/presentation/pages/login_page.dart
+++ b/user_app/lib/features/auth/presentation/pages/login_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_libs/utils/validators.dart';
 import '../../providers/auth_service.dart';
-import '../../../../theme/app_widgets.dart';
-import '../../../../core/constants/route_constants.dart';
+import 'package:shared_libs/theme/app_widgets.dart';
+import 'package:shared_libs/constants/route_constants.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({Key? key}) : super(key: key);


### PR DESCRIPTION
## Summary
- update shared library imports in `login_page.dart`
- clean up and update imports in `forgot_password_page.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414c64081c8325b580e62438567ba5