### PR TITLE
Fix order service import typo

### DIFF
--- a/shared_libs/lib/services/order_service.dart
+++ b/shared_libs/lib/services/order_service.dart
@@ -1,4 +1,4 @@
-import 'dart';:developer' as developer;
+import 'dart:developer' as developer;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_libs/constants/app_constants.dart';


### PR DESCRIPTION
## Summary
- fix incorrect Dart developer import in order service

## Testing
- `melos run test` *(fails: melos not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68415466ce788325b0d93a08f4c9a071