### PR TITLE
Fix orderServiceProvider duplication

### DIFF
--- a/seller_panel/lib/features/dashboard/presentation/pages/seller_dashboard_page.dart
+++ b/seller_panel/lib/features/dashboard/presentation/pages/seller_dashboard_page.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_libs/constants/route_constants.dart';
 import 'package:shared_libs/services/auth_service.dart';
-import 'package:shared_libs/services/order_service.dart';
+import 'package:shared_libs/services/order_service_provider.dart';
 import 'package:shared_libs/services/product_service.dart';
 import 'package:shared_libs/services/notification_service.dart';
 import 'package:shared_libs/widgets/app_widgets.dart';

--- a/seller_panel/lib/features/orders/presentation/pages/order_details_page.dart
+++ b/seller_panel/lib/features/orders/presentation/pages/order_details_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_libs/services/order_service.dart';
+import 'package:shared_libs/services/order_service_provider.dart';
 import 'package:shared_libs/widgets/app_widgets.dart';
 import 'package:shared_libs/theme/app_colors.dart';
 

--- a/seller_panel/lib/features/orders/presentation/pages/orders_management_page.dart
+++ b/seller_panel/lib/features/orders/presentation/pages/orders_management_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_libs/constants/route_constants.dart';
-import 'package:shared_libs/services/order_service.dart';
+import 'package:shared_libs/services/order_service_provider.dart';
 import 'package:shared_libs/widgets/app_widgets.dart';
 import 'package:shared_libs/theme/app_colors.dart';
 

--- a/seller_panel/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/seller_panel/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_libs/constants/route_constants.dart';
-import 'package:shared_libs/services/order_service.dart';
+import 'package:shared_libs/services/order_service_provider.dart';
 import 'package:shared_libs/widgets/app_widgets.dart';
 import 'package:shared_libs/theme/app_colors.dart';
 import 'package:fl_chart/fl_chart.dart';

--- a/shared_libs/lib/services/order_service.dart
+++ b/shared_libs/lib/services/order_service.dart
@@ -494,5 +494,3 @@ class OrderService {
   }
 }
 
-/// موفر حالة الخدمة (Riverpod)
-final orderServiceProvider = Provider<OrderService>((ref) => OrderService());


### PR DESCRIPTION
## Summary
- delete duplicate orderServiceProvider from `order_service.dart`
- import the provider file where needed

## Testing
- `melos run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415468f508832586671f3a806b93e1